### PR TITLE
pages: fixes 

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -23,6 +23,9 @@ module.exports = (grunt) ->
       cssmin:
         files: ['dist/css/bootstrap.css']
         tasks: ['cssmin:minify']
+      assemble:
+        files: ['pages/*.html', 'pages/examples/*']
+        tasks: ['assemble']
     cssmin:
       minify:
         expand: true

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           </div>
           
           <div class='panel panel-default text-left'>
-            <div class="panel-heading"><h2>Installation Instructions</h2></div>
+            <div class="panel-heading"><h2>Quick Install</h2></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
               

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           </div>
           
           <div class='panel panel-default text-left'>
-            <div class="panel-heading"><h2>Quick Install</h2></div>
+            <div class="panel-heading"><h3>Quick Install</h3></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
               
@@ -34,7 +34,7 @@
           </div>
           
           <div class='panel panel-default text-left'>
-            <div class="panel-heading"><h2>README</h2></div>
+            <div class="panel-heading"><h3>README</h3></div>
             <div class="panel-body">
               <h1>Themestrap</h1>
 <p><strong>Themestrap</strong> is a simple starter kit for constructing Twitter Bootstrap 3+ themes. It provides the skeleton

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             <a class="list-group-item" href="examples/kitchen-sink.html">View "Kitchen Sink" Example</a>
           </div>
           
-          <div class='panel text-left'>
+          <div class='panel panel-default text-left'>
             <div class="panel-heading"><h2>Installation Instructions</h2></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
@@ -33,7 +33,7 @@
             </div>
           </div>
           
-          <div class='panel text-left'>
+          <div class='panel panel-default text-left'>
             <div class="panel-heading"><h2>README</h2></div>
             <div class="panel-body">
               <h1>Themestrap</h1>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           </div>
           
           <div class='panel text-left'>
-            <div class="panel-heading">Installation Instructions</div>
+            <div class="panel-heading"><h2>Installation Instructions</h2></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
               
@@ -33,10 +33,76 @@
             </div>
           </div>
           
+          <div class='panel text-left'>
+            <div class="panel-heading"><h2>README</h2></div>
+            <div class="panel-body">
+              <h1>Themestrap</h1>
+<p><strong>Themestrap</strong> is a simple starter kit for constructing Twitter Bootstrap 3+ themes. It provides the skeleton
+for a simple, maintainable theme that always uses code directly from Bootstrap with as little replacement as
+possible.</p>
+<h2>Themestrap&#39;s Philosophy</h2>
+<ol>
+<li>A theme should be built <em>on top</em> of the framework, with as little intrusive change as possible.</li>
+<li>As the framework evolves, a theme should be easily updated to the latest version.</li>
+</ol>
+<p>To this end, Themestrap provides you with two simple files to modify: <strong>variables.less</strong>
+and <strong>theme.less</strong> (both in the <code>less</code> directory). You can tweak any and all of the Bootstrap variables 
+in <strong>variables.less</strong> and support any additional code or classes you&#39;d like in <strong>theme.less</strong>. The compiled
+theme CSS includes the Bootstrap library and will automatically pick up any overrides from variables.</p>
+<h2>Creating a Theme with Themestrap</h2>
+<p>To create a theme, first start by cloning the Themestrap repository into a directory named for
+your theme. We recommend a <code>bootstrap-theme-THEME_NAME</code> naming scheme:</p>
+<pre><code>git clone https://github.com/divshot/themestrap.git bootstrap-theme-THEME_NAME</code></pre>
+<p>Next, you should open <code>bower.json</code> and change the package name from <code>bootstrap-theme-themestrap</code>
+to match what you want your theme to be named. Now you&#39;re ready to install dependencies using
+<a href="http://gruntjs.com">Grunt</a> and <a href="https://github.com/bower/bower">Bower</a> (you must have these
+installed).</p>
+<pre><code>npm install
+bower install</code></pre>
+<p>Now you&#39;re ready to go! Simply edit <code>less/variables.less</code> and <code>less/theme.less</code> to your liking.
+When you&#39;re ready, just run <code>grunt</code> and it will compile and minify the distribution for you.
+You can also run <code>grunt watch</code> to automatically compile as you work.</p>
+<h2>Testing Out Your Theme</h2>
+<p>We&#39;ve provided a &quot;Bootstrap Kitchen Sink&quot; HTML file at <code>examples/kitchen-sink.html</code> that contains
+all of the various components in all of their variations. It may not be 100% exhaustive but it
+should give you a good idea of what your theme will look like at a glance.</p>
+<p>You can start a development server at <code>http://localhost:8000</code> by running <code>grunt serve</code>. Your theme will automatically compile while the server is running.</p>
+<h2>Deeper Customization</h2>
+<p>In cases where you need to do a more in-depth overhaul of a portion of Bootstrap&#39;s LESS, you may do so by
+simply copying over a file from Bootstrap&#39;s <code>less</code> directory into your theme&#39;s <code>less</code> directory and then
+modifying it as necessary. Example:</p>
+<pre><code>cp bower_components/bootstrap/less/alerts.less less/alerts.less</code></pre>
+<p>Because it takes path priority over the Bower-installed Bootstrap LESS, it will automatically override the 
+Bootstrap default. In fact, this is how <code>variables.less</code> works already...delete it and the default Bootstrap
+variables will be back in play.</p>
+<h2>Releasing Your Theme</h2>
+<p>Before you release your theme, you should do a few things:</p>
+<ol>
+<li>Make sure that you&#39;ve updated the package name in <code>bower.json</code> and filled out your name, the theme name and GitHub repo info</li>
+<li>Check the <code>index.html</code> file – it is generated using the information you supplied in <code>bower.json</code>.  To change it to suit your needs, edit the template <code>/pages/index.html</code>.</li>
+<li>Update the <code>README.md</code> file to be about your theme</li>
+</ol>
+<p>Once you&#39;ve done that, you should push it up to GitHub. The repository
+is already designed to be released directly onto GitHub Pages without an additional intermediary,
+so if you push to the <code>gh-pages</code> branch you should have a nice way to show off your theme!</p>
+<p>Also consider <a href="https://github.com/bower/bower#registering-packages">registering a Bower package</a>.
+If you do, remove the <code>&quot;private&quot;: true</code> property from <code>bower.json</code>.</p>
+<h2>The Themestrap Gallery</h2>
+<p>We&#39;ve created a <a href="http://code.divshot.com/themestrap">gallery of themes built with Themestrap</a>. If you
+have created a theme and want to add it to the gallery, just make a pull request to the <a href="https://github.com/divshot/themestrap/tree/gh-pages">gh-pages</a>
+branch of this repository.</p>
+<h2>Copyright and license</h2>
+<p>Copyright 2013 Divshot, Inc. under <a href="LICENSE">the Apache 2.0 license</a>.</p>
+
+            </div>
+          </div>
+          
+          <footer>
           <p><a href="https://twitter.com/share" class="twitter-share-button" data-via="divshot" data-size="large">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
 
           <p class="text-muted" style="margin-top: 100px;"><small>A <a href="https://github.com/divshot/themestrap" target="_blank">Themestrap</a> theme. Copyright &copy; 2013 Divshot, Inc. Some rights reserved.</small></p>
+          </footer>
         </div>
       </div>
     </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -24,7 +24,7 @@
           </div>
           
           <div class='panel panel-default text-left'>
-            <div class="panel-heading"><h2>Installation Instructions</h2></div>
+            <div class="panel-heading"><h2>Quick Install</h2></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
               {{#if bower.private}}

--- a/pages/index.html
+++ b/pages/index.html
@@ -24,7 +24,7 @@
           </div>
           
           <div class='panel text-left'>
-            <div class="panel-heading">Installation Instructions</div>
+            <div class="panel-heading"><h2>Installation Instructions</h2></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
               {{#if bower.private}}
@@ -35,10 +35,19 @@
             </div>
           </div>
           
+          <div class='panel text-left'>
+            <div class="panel-heading"><h2>README</h2></div>
+            <div class="panel-body">
+              {{md "README.md"}}
+            </div>
+          </div>
+          
+          <footer>
           <p><a href="https://twitter.com/share" class="twitter-share-button" data-via="divshot" data-size="large">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
 
           <p class="text-muted" style="margin-top: 100px;"><small>A <a href="https://github.com/divshot/themestrap" target="_blank">Themestrap</a> theme. Copyright &copy; 2013 Divshot, Inc. Some rights reserved.</small></p>
+          </footer>
         </div>
       </div>
     </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -23,7 +23,7 @@
             <a class="list-group-item" href="examples/kitchen-sink.html">View "Kitchen Sink" Example</a>
           </div>
           
-          <div class='panel text-left'>
+          <div class='panel panel-default text-left'>
             <div class="panel-heading"><h2>Installation Instructions</h2></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
@@ -35,7 +35,7 @@
             </div>
           </div>
           
-          <div class='panel text-left'>
+          <div class='panel panel-default text-left'>
             <div class="panel-heading"><h2>README</h2></div>
             <div class="panel-body">
               {{md "README.md"}}

--- a/pages/index.html
+++ b/pages/index.html
@@ -24,7 +24,7 @@
           </div>
           
           <div class='panel panel-default text-left'>
-            <div class="panel-heading"><h2>Quick Install</h2></div>
+            <div class="panel-heading"><h3>Quick Install</h3></div>
             <div class="panel-body">
               <p>Download the <a href="dist/css/bootstrap.css" download>bootstrap.css</a> or <a href="dist/css/bootstrap.min.css" download>bootstrap.min.css</a> files or install using Bower:</p>
               {{#if bower.private}}
@@ -36,7 +36,7 @@
           </div>
           
           <div class='panel panel-default text-left'>
-            <div class="panel-heading"><h2>README</h2></div>
+            <div class="panel-heading"><h3>README</h3></div>
             <div class="panel-body">
               {{md "README.md"}}
             </div>


### PR DESCRIPTION
(backported from a theme I am currently working on)
- add headings and `.panel-default` class to panels
- add a README panel with the rendered content from `README.md`
- `grunt watch` also builds the pages

Note that the pages are still in flux while I figure out which `package`-/`bower.json` properties we can use 
and what we should add to the 'themestrap' property. Example: "guessing" the correct location for `bower install` if it is _not_ published does not work, so we might need a 'themestrap.pkg_url' property. 
