### PR TITLE
rebuild index.html when README.md changes

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -24,7 +24,7 @@ module.exports = (grunt) ->
         files: ['dist/css/bootstrap.css']
         tasks: ['cssmin:minify']
       assemble:
-        files: ['pages/*.html', 'pages/examples/*']
+        files: ['pages/*.html', 'pages/examples/*', 'README.md']
         tasks: ['assemble']
     cssmin:
       minify:


### PR DESCRIPTION
Now that we have the contents of `README.md` in `index.html`, we need it watched as well.
